### PR TITLE
Feat: Add Dockerfile and Github actions to auto build

### DIFF
--- a/.github/workflows/push_ci.yaml
+++ b/.github/workflows/push_ci.yaml
@@ -31,3 +31,6 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/push_ci.yaml
+++ b/.github/workflows/push_ci.yaml
@@ -1,0 +1,33 @@
+# reference: https://github.com/marketplace/actions/build-and-push-docker-images#git-context
+# reference: https://docs.docker.com/ci-cd/github-actions/
+name: on push ci
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ github.repository }}:latest

--- a/.github/workflows/push_ci.yaml
+++ b/.github/workflows/push_ci.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
       -
         name: Image digest

--- a/.github/workflows/push_ci.yaml
+++ b/.github/workflows/push_ci.yaml
@@ -30,4 +30,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ github.repository }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest

--- a/.github/workflows/tag_ci.yaml
+++ b/.github/workflows/tag_ci.yaml
@@ -1,0 +1,36 @@
+# reference: https://github.com/marketplace/actions/build-and-push-docker-images#git-context
+# reference: https://docs.docker.com/ci-cd/github-actions/
+name: on tag ci
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ github.repository }}:${{ ${GITHUB_REF/refs\/tags\//} }}

--- a/.github/workflows/tag_ci.yaml
+++ b/.github/workflows/tag_ci.yaml
@@ -33,4 +33,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ github.repository }}:${{ ${GITHUB_REF/refs\/tags\//} }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ ${GITHUB_REF/refs\/tags\//} }}

--- a/.github/workflows/tag_ci.yaml
+++ b/.github/workflows/tag_ci.yaml
@@ -27,10 +27,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - 
+        name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
       -
         name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ ${GITHUB_REF/refs\/tags\//} }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/tag_ci.yaml
+++ b/.github/workflows/tag_ci.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - 
+      -
         name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
@@ -38,3 +38,6 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.tag }}
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/tag_ci.yaml
+++ b/.github/workflows/tag_ci.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.tag }}
       -
         name: Image digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:slim-bullseye
+FROM python:slim
 ADD . /app
+RUN apt update && apt install -y gcc
 RUN cd /app && pip3 install -r requirements.txt
 WORKDIR /app
 ENTRYPOINT python main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:slim-bullseye
+ADD . /app
+RUN cd /app && pip3 install -r requirements.txt
+WORKDIR /app
+ENTRYPOINT python main.py

--- a/README.md
+++ b/README.md
@@ -38,6 +38,28 @@ By default, only _admins_ are allowed to use the bot (users listed under `telegr
 
 You can see and change the current permissions configuration from the bot's chat, using the `/permissions` and `/pset` commands
 
+### Use in Docker
+
+Docker function is only tested on Linux, I guess it will work on macOS too but not Windows, because Docker in Windows does not create docker0 network interface
+
+#### Build your own image
+
+1. clone the source code
+2. rename `config.example.toml` to `config.toml`
+3. edit `config.toml` in the following way:
+  - `[telegram]` section: place your API token in `token` and your user ID in `admins`
+  - `[qbitttorrent]` section: fill the three values according to your qBittorrent WebUI settings. IMPORTANT read the config file comment about docker0 network!
+4. build your image use `docker build . -t {YOUR_TAG}`
+5. run docker `docker run -d -v ${PWD}/config.toml:/app/config.toml {YOUR_TAG}`
+
+#### Use prebuild Image
+1. Download `config.example.toml` to dir you prefer, etc: "/etc/qbbot/config.toml"
+2. edit `config.toml` in the following way:
+  - `[telegram]` section: place your API token in `token` and your user ID in `admins`
+  - `[qbitttorrent]` section: fill the three values according to your qBittorrent WebUI settings. IMPORTANT read the config file comment about docker0 network!
+3. Pull image: `docker pull {the image name is not determind}`
+5. run docker `docker run -d -v ${PWD}/config.toml:/app/config.toml {then image name is not determind}`
+
 ### Tested on...
 
 I made this bot to be able to manage what I'm downloading on my Raspberry running Raspbian (using qBittorrent's [headless version](https://github.com/qbittorrent/qBittorrent/wiki/Setting-up-qBittorrent-on-Ubuntu-server-as-daemon-with-Web-interface-(15.04-and-newer))), and that's the only environment I've tested this thing in. There's also the systemd file I'm using, `qbtbot.service` (which assumes you're going to run the bot in a python3 virtual environment)

--- a/config.example.toml
+++ b/config.example.toml
@@ -9,6 +9,8 @@ new_torrents_notification = 0 # id of a chat to notify when a new torrent is add
 
 [qbittorrent]
 url = "http://127.0.0.1:8080/"
+# for docker user the url should not be 127.0.0.1 because the container is connected to docker0 network
+# url = "http://172.17.0.1:8080" # docker0 network, the 172.0.0.1 is host ip addr
 login = "admin"
 secret = "adminadmin"
 toggle_torrents_queueing_every_night = false # if enabled, torrents queueing will be disabled and re-enabled every night


### PR DESCRIPTION
## This PR enable auto build and push to DockerHub.
On push to master, the Github action will auto build and tag as `latest`
On create new tag, the Github action will auto build and tag as the new tag.

All actions is tested in my repo. The corresponding DockerHub url is `https://hub.docker.com/r/yuhangq/qbittorrent-bot/tags?page=1&ordering=last_updated`, I will delete the DockerHub image once this PR is merged

reference: https://github.com/marketplace/actions/build-and-push-docker-images#git-context
reference: https://docs.docker.com/ci-cd/github-actions/

**IMPORTANT**
**PLZ follow the reference 2 to generate your access token and set it to your repo's secret. The key should be  `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`**
`https://github.com/zeroone2numeral2/qbittorrent-bot/compare/master...qinyuhang:master#diff-5a5ab812a2f870c66dfedabfb94a7491a6bd3d7c84cdf6ebd81d967ac8d68f6fR25`



Here is a screen shot of my configuration
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/6239057/136323523-f28925be-2793-4fe5-b115-0a321ac110b7.png">

