### PR TITLE
Add proxy support

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -4,8 +4,20 @@ from telegram.ext import Defaults
 from .bot import CustomUpdater
 from config import config
 
+REQUEST_KWARGS = {}
+if config.proxy.url:
+    REQUEST_KWARGS['proxy_url'] = config.proxy.url 
+    if config.proxy.username:
+        REQUEST_KWARGS['urllib3_proxy_kwargs'] = {
+            'username': config.proxy.username,
+            'password': config.proxy.password 
+        }
+
+
+
 updater = CustomUpdater(
     token=config.telegram.token,
     defaults=Defaults(timeout=config.telegram.timeout, disable_web_page_preview=True),
-    workers=config.telegram.workers
+    workers=config.telegram.workers,
+    request_kwargs=REQUEST_KWARGS,
 )

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,11 @@ workers = 1 # number of python-telegram-bot workers. One worker is more than eno
 timeout = 120 # requests timeout in seconds
 errors_log_chat = 0 # chat where to post exceptions. If disabled (0), the first user id in 'admins' will be used
 
+[proxy]
+url = ""        # socks5(h)://ip:port or http://user:pass@ip:port/
+username = ""   # Socks only, Use url embeded user/pass for http(s)
+password = ""   # Socks only
+
 [notifications]
 completed_torrents = 0 # id of a chat to notify when a torrent is completed. 0 to disable
 no_notification_tag = "" # if a torrent has this tag, do not send the completed download notification in the notifications chat (if set). Case insensitive. "" (empty string) to disable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot==13.7
+python-telegram-bot[socks]==13.7
 python-qbittorrent>=0.4.2
 toml
 requests


### PR DESCRIPTION
Proxy support is added based on python-telegram-bot support for HTTP, HTTPS and Socks proxies
Also [socks] dependency is added to requirements.txt as needed by python-telegram-bot to support socks
leaving url empty disables proxy and leaving username empty disables authentication