### PR TITLE
Purge gcc and apt cache after python requirements installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:slim
 ADD . /app
-RUN apt update && apt install -y gcc
-RUN cd /app && pip3 install -r requirements.txt
+RUN apt update && apt install -y gcc \
+    && cd /app \
+    && pip3 install -r requirements.txt \
+    && apt purge --auto-remove -y gcc \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 ENTRYPOINT python main.py


### PR DESCRIPTION
This will decrease container image size.